### PR TITLE
优化控制台补全

### DIFF
--- a/src/main/java/com/webank/wecross/console/Shell.java
+++ b/src/main/java/com/webank/wecross/console/Shell.java
@@ -161,12 +161,18 @@ public class Shell {
                     case "call":
                         {
                             rpcFace.call(params, pathMaps);
+                            if (params.length >= 4) {
+                                JlineUtils.addContractMethodCompleters(completers, params[3]);
+                            }
                             break;
                         }
                     case "send":
                     case "sendTransaction":
                         {
                             rpcFace.sendTransaction(params, pathMaps);
+                            if (params.length >= 4) {
+                                JlineUtils.addContractMethodCompleters(completers, params[3]);
+                            }
                             break;
                         }
                     case "genTimelock":
@@ -246,16 +252,25 @@ public class Shell {
                             if (params.length > 2 && isPath(params[1])) {
                                 JlineUtils.addPathCompleters(completers, params[1]);
                             }
+                            if (params.length >= 4) {
+                                JlineUtils.addOrgCompleters(completers, params[3]);
+                            }
                             break;
                         }
                     case "fabricInstantiate":
                         {
                             fabricCommand.instantiate(params);
+                            if (params.length >= 4) {
+                                JlineUtils.addOrgCompleters(completers, params[3]);
+                            }
                             break;
                         }
                     case "fabricUpgrade":
                         {
                             fabricCommand.upgrade(params);
+                            if (params.length >= 4) {
+                                JlineUtils.addOrgCompleters(completers, params[3]);
+                            }
                             break;
                         }
                     default:

--- a/src/main/java/com/webank/wecross/console/common/HelpInfo.java
+++ b/src/main/java/com/webank/wecross/console/common/HelpInfo.java
@@ -239,7 +239,7 @@ public class HelpInfo {
 
     public static void getTransactionIDsHelp() {
         ConsoleUtils.singleLine();
-        System.out.println("Get all transaction ids");
+        System.out.println("Get transaction ids of 2pc");
         System.out.println("Usage: getTransactionIDs [path] [account] [option]");
         System.out.println("path -- the path of the contract resource in wecross router");
         System.out.println("account -- choose an account to sign");

--- a/src/main/java/com/webank/wecross/console/common/JlineUtils.java
+++ b/src/main/java/com/webank/wecross/console/common/JlineUtils.java
@@ -5,8 +5,13 @@ import java.nio.file.Paths;
 import java.util.*;
 import org.jline.builtins.Completers.DirectoriesCompleter;
 import org.jline.builtins.Completers.FilesCompleter;
-import org.jline.reader.*;
-import org.jline.reader.impl.completer.*;
+import org.jline.reader.Completer;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.impl.completer.AggregateCompleter;
+import org.jline.reader.impl.completer.ArgumentCompleter;
+import org.jline.reader.impl.completer.NullCompleter;
+import org.jline.reader.impl.completer.StringsCompleter;
 import org.jline.terminal.Attributes;
 import org.jline.terminal.Attributes.ControlChar;
 import org.jline.terminal.Terminal;
@@ -37,11 +42,11 @@ public class JlineUtils {
 
     private static List<String> pathVarNotSupportedCommands =
             Arrays.asList(
-                    //                    "bcosDeploy",
-                    //                    "bcosRegister",
-                    //                    "fabricInstall",
-                    //                    "fabricInstantiate",
-                    //                    "fabricUpgrade",
+                    "bcosDeploy",
+                    "bcosRegister",
+                    "fabricInstall",
+                    "fabricInstantiate",
+                    "fabricUpgrade",
                     "getTransactionIDs");
 
     private static List<String> fabricCommands =

--- a/src/main/java/com/webank/wecross/console/common/WelcomeInfo.java
+++ b/src/main/java/com/webank/wecross/console/common/WelcomeInfo.java
@@ -41,7 +41,7 @@ public class WelcomeInfo {
         sb.append("commitTransaction                  Commit a 2pc transaction.\n");
         sb.append("rollbackTransaction                Rollback a 2pc transaction.\n");
         sb.append("getTransactionInfo                 Get info of specified transaction.\n");
-        sb.append("getTransactionIDs                  Get all transaction ids.\n");
+        sb.append("getTransactionIDs                  Get transaction ids of 2pc.\n");
         sb.append("bcosDeploy                         Deploy contract in BCOS chain.\n");
         sb.append("bcosRegister                       Register contract abi in BCOS chain.\n");
         sb.append("fabricInstall                      Install chaincode in fabric chain.\n");


### PR DESCRIPTION
# 控制台优化补全

1. BCOS/Fabric部署合约相关命令可以补全合约文件路径（相对路径）；
2. method，org参数可以补全历史使用参数；
3. 修复部分补全器bug。