### PR TITLE
Add chaincode helloworld

### DIFF
--- a/src/main/resources/contracts/chaincode/helloworld/helloworld.go
+++ b/src/main/resources/contracts/chaincode/helloworld/helloworld.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+	"github.com/hyperledger/fabric/protos/peer"
+)
+
+const NAME = "name"
+
+type HelloWorld struct {
+}
+
+func (hw *HelloWorld) Init(stub shim.ChaincodeStubInterface) peer.Response {
+	// init the variable name with "Hello, World!"
+	err := stub.PutState(NAME, []byte("Hello, World!"))
+	if err != nil {
+		return shim.Error("fail in initializing smart contract HelloWorld")
+	}
+	return shim.Success(nil)
+}
+
+// Invoke is called per transaction on the chaincode. Each transaction is
+// either a 'get' or a 'set'.
+
+func (hw *HelloWorld) Invoke(stub shim.ChaincodeStubInterface) peer.Response {
+	// Extract the function and args from the transaction proposal
+	fn, args := stub.GetFunctionAndParameters()
+
+	var result string
+	var err error
+	if fn == "set" {
+		result, err = set(stub, args)
+	} else if fn == "get" { // assume 'get' even if fn is nil
+		result, err = get(stub)
+	} else {
+		err = fmt.Errorf("invalid call")
+	}
+
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+
+	// Return the result as success payload
+	return shim.Success([]byte(result))
+}
+
+// Set updates the variable name with a new value. If succeed, the updated value is back.
+func set(stub shim.ChaincodeStubInterface, args []string) (string, error) {
+	if len(args) != 1 {
+		return "", fmt.Errorf("no value is input")
+	}
+
+	err := stub.PutState(NAME, []byte(args[0]))
+	if err != nil {
+		return "", fmt.Errorf("failed in set: %s", err)
+	}
+	return args[0], nil
+}
+
+// Get returns the value of the variable name
+func get(stub shim.ChaincodeStubInterface) (string, error) {
+	value, err := stub.GetState(NAME)
+	if err != nil {
+		return "", fmt.Errorf("failed in get: %s", err)
+	}
+	if value == nil {
+		return "", fmt.Errorf("variable name does not exist")
+	}
+	return string(value), nil
+}
+
+// main function starts up the chaincode in the container during instantiate
+func main() {
+	if err := shim.Start(new(HelloWorld)); err != nil {
+		fmt.Printf("Error starting HelloWrold chaincode: %s", err)
+	}
+}


### PR DESCRIPTION
## hello.go
与HelloWorld.sol功能相同的golang版chaincode
## 部署
使用WeCross Demo在启动WeCross混合场景跨链网络进行测试
* 将helloworld.go加入到WeCross-Console下conf/contracts/chaincode/helloworld下
* 启动WeCross-Console,登录跨链账户`login org1-admin 123456`
* 使用如下代码部署helloworld：
```
setDefaultAccount Fabric1.4 1
fabricInstall payment.fabric-mychannel.helloworld Org1 contracts/chaincode/helloworld 1.0 GO_LANG
setDefaultAccount Fabric1.4 2
fabricInstall payment.fabric-mychannel.helloworld Org2 contracts/chaincode/helloworld 1.0 GO_LANG
fabricInstantiate payment.fabric-mychannel.helloworld ["Org1","Org2"] contracts/chaincode/helloworld 1.0 GO_LANG default []
```
注意最后的初始化参数传入为空

此后需要等待一定时间，使用`listResources`命令查看已部署的资源，结果如下：
```
[WeCross.org1-admin]> listResources 
path: payment.bcos-gm.HelloWorld, type: GM_BCOS2.0, distance: 1
path: payment.bcos-gm.WeCrossHub, type: GM_BCOS2.0, distance: 1
path: payment.bcos-group1.HelloWorldGroup1, type: BCOS2.0, distance: 0
path: payment.bcos-group1.WeCrossHub, type: BCOS2.0, distance: 0
path: payment.bcos-group2.HelloWorldGroup2, type: BCOS2.0, distance: 0
path: payment.bcos-group2.WeCrossHub, type: BCOS2.0, distance: 0
path: payment.fabric-mychannel.WeCrossHub, type: Fabric1.4, distance: 1
path: payment.fabric-mychannel.helloworld, type: Fabric1.4, distance: 1
path: payment.fabric-mychannel.sacc, type: Fabric1.4, distance: 1
total: 9
```

## 调用
依次输入：
`call payment.fabric-mychannel.helloworld get` >> Result  : [Hello, World!]
`sendTransaction payment.fabric-mychannel.helloworld set Leo` >> Result  : [Leo]
`call payment.fabric-mychannel.helloworld get` >> Result  : [Leo]

