### PR TITLE
Add Sacc.sol

### DIFF
--- a/src/main/resources/contracts/solidity/Sacc.sol
+++ b/src/main/resources/contracts/solidity/Sacc.sol
@@ -1,0 +1,17 @@
+pragma solidity >=0.4.0 <0.6.0;
+
+contract SimpleAsset {
+    mapping(string => string) ledger;
+    constructor(string memory key,string memory value) public{
+        ledger[key] = value;
+    }
+
+    function set(string memory key,string memory value) public returns (string memory){
+        ledger[key] = value;
+        return value;
+    }
+
+    function get(string memory key) public view returns(string memory){
+        return ledger[key];
+    }
+}


### PR DESCRIPTION
## Sacc.sol
为fabric的chaincode示例sacc.go的solidity实现。

## 部署
使用WeCross-Demo中的混合场景进行合约部署。将Sacc.go放在WeCross-Console的conf/contracts/solidity下。
* 首先使用`login org1-admin 123456`登入跨链账户。
* 输入`bcosDeploy payment.bcos-gm.sacc contracts/solidity/Sacc.sol SimpleAsset 1.0 Leo 9999`,注意最后两个参数为合约的初始参数，即设置键值Leo为9999。
* `listResources`输出已部署资源如下。
```
[WeCross.org1-admin]> listResources 
path: payment.bcos-gm.HelloWorld, type: GM_BCOS2.0, distance: 1
path: payment.bcos-gm.WeCrossHub, type: GM_BCOS2.0, distance: 1
path: payment.bcos-gm.sacc, type: GM_BCOS2.0, distance: 1
path: payment.bcos-group1.HelloWorldGroup1, type: BCOS2.0, distance: 0
path: payment.bcos-group1.WeCrossHub, type: BCOS2.0, distance: 0
path: payment.bcos-group2.HelloWorldGroup2, type: BCOS2.0, distance: 0
path: payment.bcos-group2.WeCrossHub, type: BCOS2.0, distance: 0
path: payment.fabric-mychannel.WeCrossHub, type: Fabric1.4, distance: 1
path: payment.fabric-mychannel.sacc, type: Fabric1.4, distance: 1
total: 9
```
## 测试
* `login`
* `call payment.bcos-gm.sacc get Leo` >> Result  : [9999]
* `sendTransaction payment.bcos-gm.sacc set Thea 100` >> Result  : [100]
* `call payment.bcos-gm.sacc get Thea` >> Result  : [100]
* `sendTransaction payment.bcos-gm.sacc set Leo 0` >> Result  : [0]
* `call payment.bcos-gm.sacc get Leo` >> Result  : [0]